### PR TITLE
chore: remove xerox prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xerox/browserslist-browserstack",
+  "name": "browserslist-browserstack",
   "version": "2.1.1",
   "description": "Run BrowserStack tests for all browsers in project’s Browserslist config (with additional include/exclude filters).",
   "keywords": [


### PR DESCRIPTION
BREAKING CHANGE: `@xerox/` prefix removed from npm package going forward