### PR TITLE
feat: add format function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ _Note: none of these options are required, by default `getCapabilities` will jus
 | operatingSystems.exclude | `Array` | A list of [OperatingSystemFilter's](#OperatingSystemFilter) to exclude in the capabilities list. | `[OperatingSystemFilter.OSX]` | `[]` |
 | operatingSystemVersion.include | `Array` | A list of [operatingSystemVersion's](#operatingSystemVersion) to include in the capabilities list. | `[operatingSystemVersion.SEVEN, operatingSystemVersion.XP]` | `[]` |
 | operatingSystemVersion.exclude | `Array` | A list of [operatingSystemVersion's](#operatingSystemVersion) to exclude in the capabilities list. | `[operatingSystemVersion.EL_CAPITAN, operatingSystemVersion.HIGH_SIERRA]` | `[]` |
-| formatForSelenium | `Boolean` | Whether to add browserName and browserVersion properties to the outputted capabilites, as selenium does not understand BrowserStack's `browser` and `browser_version` equivelants. | `false` | `true`
+| format | `Function` | User defined function that accepts `[Capabilities]` as an argument. Should return a formatted `capabilities` Object. Defaults to `formatForSelenium()` helper, which is exported by the package. Optional.
 
 ## Types
 These are the core types exported by `browserslist-browserstack`.

--- a/source/__tests__/index.test.ts
+++ b/source/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { mocked } from 'ts-jest/utils';
 import * as moduleUnderTest from '../index';
 import nodeFetch from 'node-fetch';
+import { formatForKarma } from '../helpers';
 
 const mockFetch = mocked(nodeFetch, true);
 
@@ -234,12 +235,26 @@ describe('getCapabilities', () => {
         browserslist: {
           queries: 'IE 10',
         },
-        formatForSelenium: false,
+        format: false,
       });
       for (const capability of capabilities) {
         expect(capability).not.toHaveProperty('browserName');
         expect(capability).not.toHaveProperty('browserVersion');
       }
+    });
+
+    test('formatting for karma', async () => {
+      const capabilities = await moduleUnderTest.default({
+        username: '---username---',
+        accessKey: '---accessKey---',
+        browserslist: {
+          queries: 'IE 10',
+        },
+        format: formatForKarma,
+      });
+
+      expect(capabilities).toHaveProperty('browsers');
+      expect(capabilities).toHaveProperty('customLaunchers');
     });
   });
 });

--- a/source/helpers.ts
+++ b/source/helpers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Filters } from './types';
+import { Capability, Filters } from './types';
 
 /**
  * Determines whether a given value should be filtered out or not, using an array of valid include values and invalid exclude values.
@@ -63,3 +63,38 @@ export function arraysEqual(array1: any[], array2: any[]): boolean {
   }
   return true;
 }
+
+// define a loose version of Object so it can be extended
+const looseObj: { [k: string]: any } = {};
+
+export const formatForSelenium = (capabilities: [Capability]) => {
+  return capabilities.map(
+    (capability: Capability): Capability => ({
+      browserName: capability.browser,
+      browserVersion: capability.browser_version ?? undefined,
+      ...capability,
+    })
+  );
+};
+
+export const formatForKarma = (
+  capabilities: [Capability],
+  browserBase: string
+) => {
+  const res = {} as typeof looseObj;
+  // store each capability in a separate key with a browser name as the key
+  capabilities.forEach((capability) => {
+    // extend the object
+    capability.base = browserBase;
+    // define a unique browser name
+    const { browser, browser_version, os, os_version } = capability;
+    const karmaBrowserName = `bs_${browser}_${browser_version}_${os}_${os_version}`;
+    // set the browser name as the key for the capabilities object
+    res[karmaBrowserName] = capability;
+  });
+
+  return {
+    browsers: Object.keys(res),
+    customLaunchers: res,
+  };
+};

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,11 +1,12 @@
 import browserslist from 'browserslist';
 import { Capability, Options, Browser } from './types';
 import { getAllCapabilities, filterCapabilities } from './capabilities';
+import { formatForSelenium } from './helpers';
 
 const defaultOptions: Options = {
   username: process.env.BROWSER_STACK_USERNAME,
   accessKey: process.env.BROWSER_STACK_ACCESS_KEY,
-  formatForSelenium: true,
+  format: formatForSelenium,
 };
 
 /**
@@ -47,14 +48,8 @@ export default async function getCapabilities(
       allSupportedBrowsers,
       options
     );
-    if (options.formatForSelenium) {
-      return capabilities.map(
-        (capability: Capability): Capability => ({
-          browserName: capability.browser,
-          browserVersion: capability.browser_version ?? undefined,
-          ...capability,
-        })
-      );
+    if (typeof options.format === 'function') {
+      return options.format(capabilities);
     } else {
       return capabilities;
     }
@@ -75,3 +70,4 @@ export {
   FetchError,
   ResponseError,
 } from './types';
+export { formatForSelenium, formatForKarma } from './helpers';

--- a/source/types.ts
+++ b/source/types.ts
@@ -47,7 +47,7 @@ export interface Options {
     | AndroidOperatingSystemVersionFilter
   >;
   devices?: Filters<DeviceFilter>;
-  formatForSelenium?: boolean;
+  format?: Function | false;
 }
 
 export interface Browser {
@@ -66,6 +66,8 @@ export interface Capability extends Browser {
   // selenium
   browserName?: string;
   browserVersion?: string;
+  // browserStack
+  base?: string;
 }
 
 export enum OperatingSystemFilter {


### PR DESCRIPTION
This PR replaces the `formatForSelenium` config option with a `format` option. That key accepts a function or `false`. The function will recieve one argument, `capabilites` array, wich it can then use to create any output. 

The purpose of this change is to allow users to export the results in any format they wish.

The `format` functionality defailts to `formatForSelenium`'s previous behavior. It does this by using a helper function of the same name to format the `capabilities` array. The package also exports a new `formatForKarma`. Both can be references as examples for other formatting functions that can be user-defined. The helper functions are exported by the package.

The PR also includes a new test for the exported `formatForKarma` helper function.

## Example

These changes allow the package to be used similarly to how it is below.

``` js
const mapBrowsersListToBrowserStackLaunchers = async () => {
  return browserList_browserStack 
    .default({
      username: process.env.BROWSERSTACK_USERNAME,
      accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
      browserslist: {
        queries: [
          "ie >= 11",
          "last 1 Android versions",
          "last 1 Chrome versions",
          "last 1 Firefox versions",
          "last 1 Safari versions",
          "last 1 iOS versions",
          "last 1 Edge versions",
        ],
      },
      format: (capabilities) =>
        browserList_browserStack.formatForKarma(capabilities, "BrowserStack"),
    })
    .then((res) => {
      return res;
    });
};
```

Where the output looks something like this:

``` js
{
  browsers: [
    'bs_chrome_90.0_Windows_7',
    'bs_ie_11.0_Windows_7',
    'bs_firefox_88.0_Windows_7',
    'bs_edge_90.0_Windows_7',
    'bs_chrome_90.0_Windows_8',
    'bs_firefox_88.0_Windows_8',
    'bs_edge_90.0_Windows_8',
    'bs_chrome_90.0_Windows_8.1'...
  ],
  customLaunchers: {
    'bs_chrome_90.0_Windows_7': {
      os: 'Windows',
      os_version: '7',
      browser: 'chrome',
      device: null,
      browser_version: '90.0',
      real_mobile: null,
      base: 'BrowserStack'
    },
    'bs_ie_11.0_Windows_7': {
      os: 'Windows',
      os_version: '7',
      browser: 'ie',
      device: null,
      browser_version: '11.0',
      real_mobile: null,
      base: 'BrowserStack'
    },
    'bs_firefox_88.0_Windows_7': {
      os: 'Windows',
      os_version: '7',
      browser: 'firefox',
      device: null,
      browser_version: '88.0',
      real_mobile: null,
      base: 'BrowserStack'
    },
    'bs_edge_90.0_Windows_7': {
      os: 'Windows',
      os_version: '7',
      browser: 'edge',
      device: null,
      browser_version: '90.0',
      real_mobile: null,
      base: 'BrowserStack'
    },
    'bs_chrome_90.0_Windows_8': {
      os: 'Windows',
      os_version: '8',
      browser: 'chrome',
      device: null,
      browser_version: '90.0',
      real_mobile: null,
      base: 'BrowserStack'
    },
    'bs_firefox_88.0_Windows_8': {
      os: 'Windows',
      os_version: '8',
      browser: 'firefox',
      device: null,
      browser_version: '88.0',
      real_mobile: null,
      base: 'BrowserStack'
    },
    'bs_edge_90.0_Windows_8': {
      os: 'Windows',
      os_version: '8',
      browser: 'edge',
      device: null,
      browser_version: '90.0',
      real_mobile: null,
      base: 'BrowserStack'
    },...
}
```